### PR TITLE
WIP: Add an `onBeforeStop` hook.

### DIFF
--- a/lib/route_controller_client.js
+++ b/lib/route_controller_client.js
@@ -17,6 +17,7 @@ RouteController.prototype.init = function (options) {
   this._computation = null;
   this._paramsDep = new Tracker.Dependency;
   this.location = Iron.Location;
+  this._boundOnBeforeUnload = this._onBeforeUnload.bind(this);
 };
 
 RouteController.prototype.getParams = function () {
@@ -252,6 +253,10 @@ RouteController.prototype._runRoute = function (route, url, done) {
   // this.next() to progress to the next handler, just like Connect
   // middleware.
   this.runHooks('onAfterAction', 'after');
+
+  // Register our 'beforeunload' handler, if we haven't already.
+  // Not sure if this is the right place to put this but it works.
+  window.addEventListener('beforeunload', this._boundOnBeforeUnload);
 };
 
 /**
@@ -322,10 +327,42 @@ RouteController.prototype.renderRegions = function () {
 RouteController.prototype.stop = function () {
   RouteController.__super__.stop.call(this);
 
+  var reasonToPreventStop = this._runOnBeforeStopHooks();
+  if (reasonToPreventStop &&
+    !window.confirm(reasonToPreventStop + '\n\nAre you sure you want to navigate away?')) {
+    return false;
+  }
+
   if (this._computation)
     this._computation.stop();
+  window.removeEventListener('beforeunload', this._boundOnBeforeUnload);
   this.runHooks('onStop', 'unload');
   this.isStopped = true;
+
+  return true;
+};
+
+RouteController.prototype._runOnBeforeStopHooks = function () {
+  var beforeStopHooks = this._collectHooks('onBeforeStop', 'beforeunload');
+
+  var reasonToPreventStop;
+  _.some(beforeStopHooks, function(hook) {
+    reasonToPreventStop = hook.call(this);
+    return reasonToPreventStop;
+  }, this);
+
+  return reasonToPreventStop;
+};
+
+RouteController.prototype._onBeforeUnload = function(e) {
+  // Cross-platform implementation per MDN.
+  // In Chrome (at least) we must not assign to `returnValue` unless we actually have a message
+  // or else a confirmation dialog will be presented to show the r-value (even a falsy r-value).
+  var confirmationMessage = this._runOnBeforeStopHooks();
+  if (confirmationMessage) {
+    (e || window.event).returnValue = confirmationMessage;
+  }
+  return confirmationMessage;
 };
 
 /**

--- a/lib/router_client.js
+++ b/lib/router_client.js
@@ -67,18 +67,25 @@ Router.prototype.dispatch = function (url, context, done) {
 
   assert(typeof url === 'string', "expected url string in router dispatch");
 
+  // even if we already have an existing controller we'll stop it
+  // and start it again. But since the actual controller instance
+  // hasn't changed, the helpers won't need to rerun.
+  var stopCanceled = false;
+  if (this._currentController) {
+    stopCanceled = !this._currentController.stop();
+  }
+  if (stopCanceled) {
+    // `done` must be called synchronously in order for cancellation to work. It appears as though
+    // the expectation is that it's called synchronously anyway.
+    done && done.call(this._currentController, null /* err */, true /* dispatchCanceled */);
+    return this._currentController;
+  }
+
   var controller = this._currentController;
   var route = this.findFirstRoute(url);
   var prevRoute = this._currentRoute;
 
   this._currentRoute = route;
-
-
-  // even if we already have an existing controller we'll stop it
-  // and start it again. But since the actual controller instance
-  // hasn't changed, the helpers won't need to rerun.
-  if (this._currentController)
-    this._currentController.stop();
 
   //XXX Instead of this, let's consider making all RouteControllers
   //    singletons that get configured at dispatch. Will revisit this
@@ -178,12 +185,13 @@ Router.prototype.start = function () {
     var hash, pathname, search;
     var current = self._currentController;
 
+    var dispatchWasCanceled = false;
     if (!current || (prevLocation && prevLocation.path !== loc.path)) {
-      controller = self.dispatch(loc.href, null, function onRouterStartDispatchCompleted (error) {
-        // if we're going to the server cancel the url change
-        if (!this.isHandled()) {
+      controller = self.dispatch(loc.href, null, function onRouterStartDispatchCompleted (error, dispatchCanceled) {
+        // if dispatch was canceled or we're going to the server cancel the url change
+        if (dispatchCanceled || !this.isHandled()) {
           loc.cancelUrlChange();
-          window.location = loc.path;
+          dispatchWasCanceled = true;
         }
       });
     } else {
@@ -193,7 +201,9 @@ Router.prototype.start = function () {
       current.configureFromUrl(loc.href);
     }
 
-    prevLocation = loc;
+    if (!dispatchWasCanceled) {
+      prevLocation = loc;
+    }
   });
 };
 


### PR DESCRIPTION
Which is registered as a 'beforeunload' handler and also runs before navigating to
a different route, presenting a similar confirmation dialog.

WIP: Requires a new version of Iron Location containing https://github.com/iron-meteor/iron-location/pull/17, documentation, tests? For these reasons, this isn't being submitted to upstream yet. We'll run this locally for the meantime—I'm just putting it up if you want to review @bradvogel.
